### PR TITLE
Refactor: rename package from config to envconfig for clarity

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,7 +1,7 @@
 // Package config dostarcza funkcjonalność do ładowania konfiguracji z zmiennych środowiskowych
 // do struktur Go przy użyciu tagów struktury. Wspiera różne typy danych, wartości domyślne
 // oraz zagnieżdżone struktury dla lepszej organizacji konfiguracji.
-package config
+package envconfig
 
 import (
 	"reflect"

--- a/config.go
+++ b/config.go
@@ -1,4 +1,4 @@
-// Package config dostarcza funkcjonalność do ładowania konfiguracji z zmiennych środowiskowych
+// Package envconfig dostarcza funkcjonalność do ładowania konfiguracji z zmiennych środowiskowych
 // do struktur Go przy użyciu tagów struktury. Wspiera różne typy danych, wartości domyślne
 // oraz zagnieżdżone struktury dla lepszej organizacji konfiguracji.
 package envconfig

--- a/config_test.go
+++ b/config_test.go
@@ -1,4 +1,4 @@
-package config
+package envconfig
 
 import (
 	"errors"

--- a/errors.go
+++ b/errors.go
@@ -1,6 +1,6 @@
 // Package config dostarcza funkcjonalność do ładowania konfiguracji z zmiennych środowiskowych
 // do struktur Go przy użyciu tagów struktury.
-package config
+package envconfig
 
 import (
 	"errors"
@@ -27,8 +27,10 @@ type RequiredFieldError struct {
 
 // Error implementuje interfejs error
 func (e *RequiredFieldError) Error() string {
-	return fmt.Sprintf("%s: field '%s' is required but no value was provided (env: %s)",
-		ErrMissingRequired.Error(), e.FieldName, e.EnvName)
+	return fmt.Sprintf(
+		"%s: field '%s' is required but no value was provided (env: %s)",
+		ErrMissingRequired.Error(), e.FieldName, e.EnvName,
+	)
 }
 
 // ParseError reprezentuje błąd podczas parsowania wartości
@@ -41,8 +43,10 @@ type ParseError struct {
 
 // Error implementuje interfejs error
 func (e *ParseError) Error() string {
-	return fmt.Sprintf("failed to parse value '%s' as %s for field '%s': %v",
-		e.Value, e.FieldType, e.FieldName, e.Err)
+	return fmt.Sprintf(
+		"failed to parse value '%s' as %s for field '%s': %v",
+		e.Value, e.FieldType, e.FieldName, e.Err,
+	)
 }
 
 // Unwrap implementuje interfejs errors.Unwrap

--- a/errors.go
+++ b/errors.go
@@ -1,4 +1,4 @@
-// Package config dostarcza funkcjonalność do ładowania konfiguracji z zmiennych środowiskowych
+// Package envconfig dostarcza funkcjonalność do ładowania konfiguracji z zmiennych środowiskowych
 // do struktur Go przy użyciu tagów struktury.
 package envconfig
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,4 +1,4 @@
-package config
+package envconfig
 
 import (
 	"errors"

--- a/parser.go
+++ b/parser.go
@@ -1,4 +1,4 @@
-// Package config dostarcza funkcjonalność do ładowania konfiguracji z zmiennych środowiskowych
+// Package envconfig dostarcza funkcjonalność do ładowania konfiguracji ze zmiennych środowiskowych
 // do struktur Go przy użyciu tagów struktury.
 package envconfig
 

--- a/parser.go
+++ b/parser.go
@@ -1,6 +1,6 @@
 // Package config dostarcza funkcjonalność do ładowania konfiguracji z zmiennych środowiskowych
 // do struktur Go przy użyciu tagów struktury.
-package config
+package envconfig
 
 import (
 	"fmt"

--- a/parser_test.go
+++ b/parser_test.go
@@ -1,4 +1,4 @@
-package config
+package envconfig
 
 import (
 	"errors"


### PR DESCRIPTION
This pull request renames the config package to envconfig to better reflect its actual purpose — handling environment-based configuration.
The change improves clarity and avoids confusion with other types of configuration sources (e.g., file-based config, runtime config).

All import paths and internal references to the config package have been updated accordingly.